### PR TITLE
Serialise config FeatureFlag value

### DIFF
--- a/NVDAPlugin/globalPlugins/CommandSocket/handler.py
+++ b/NVDAPlugin/globalPlugins/CommandSocket/handler.py
@@ -3,6 +3,7 @@ from http.server import BaseHTTPRequestHandler
 from http import HTTPStatus
 import json
 from urllib.parse import urlsplit, parse_qs
+from .settings_serializer import NVDASettingsSerializer
 
 import versionInfo
 
@@ -43,9 +44,9 @@ class RequestHandler(BaseHTTPRequestHandler):
 			self._set_headers('text/plain')
 			query = urlsplit(self.path).query
 			query_parts = parse_qs(query)
-			settings = query_parts['q'][0].split(',') if 'q' in query_parts and len(query_parts['q']) == 1 else []
-			self.wfile.write(json.dumps(RequestHandler._get_settings(settings)).encode('utf-8'))
-
+			requested_settings = query_parts['q'][0].split(',') if 'q' in query_parts and len(query_parts['q']) == 1 else []
+			json_settings = NVDASettingsSerializer().encode(RequestHandler._get_settings(requested_settings))
+			self.wfile.write(json_settings.encode('utf-8'))
 
 	def do_POST(self):
 		if not self.path or self.path != '/settings':

--- a/NVDAPlugin/globalPlugins/CommandSocket/settings_serializer.py
+++ b/NVDAPlugin/globalPlugins/CommandSocket/settings_serializer.py
@@ -1,0 +1,14 @@
+import json
+from typing import Any
+from config import featureFlag
+
+
+def _serialize_feature_flag(flag: featureFlag.FeatureFlag) -> str:
+    return flag.value.name
+
+
+class NVDASettingsSerializer(json.JSONEncoder):
+    def default(self, o) -> Any:
+        if isinstance(o, featureFlag.FeatureFlag):
+            return _serialize_feature_flag(o)
+        return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
This closes #24 by introducing a custom `JSONEncoder` subclass which is capable of serialising a `FeatureFlag` instance value.