### PR TITLE
Updates to command ID handling

### DIFF
--- a/Server/command/command.go
+++ b/Server/command/command.go
@@ -11,13 +11,13 @@ const (
 type EmptyParams interface{}
 
 type AnyCommand struct {
-	ID     string      `json:"id"`
+	ID     uint        `json:"id"`
 	Method string      `json:"method"`
 	Params interface{} `json:"params"`
 }
 
 type NewSessionCommand struct {
-	ID     string                  `json:"id"`
+	ID     uint                    `json:"id"`
 	Method string                  `json:"method"`
 	Params NewSessionCommandParams `json:"params"`
 }
@@ -37,7 +37,7 @@ type NewSessionCommandCapabilitiesRequestParameters struct {
 }
 
 type GetSettingsCommand struct {
-	ID     string                              `json:"id"`
+	ID     uint                                `json:"id"`
 	Method string                              `json:"method"`
 	Params VendorSettingsGetSettingsParameters `json:"params"`
 }
@@ -51,13 +51,13 @@ type VendorSettingsGetSettingsParameters struct {
 }
 
 type GetSupportedSettingsCommand struct {
-	ID     string      `json:"id"`
+	ID     uint        `json:"id"`
 	Method string      `json:"method"`
 	Params EmptyParams `json:"params"`
 }
 
 type SetSettingsCommand struct {
-	ID     string                              `json:"id"`
+	ID     uint                                `json:"id"`
 	Method string                              `json:"method"`
 	Params VendorSettingsSetSettingsParameters `json:"params"`
 }
@@ -72,7 +72,7 @@ type VendorSettingsSetSettingsParameters struct {
 }
 
 type PressKeysCommand struct {
-	ID     string              `json:"id"`
+	ID     uint                `json:"id"`
 	Method string              `json:"method"`
 	Params PressKeysParameters `json:"params"`
 }

--- a/Server/response/response.go
+++ b/Server/response/response.go
@@ -7,14 +7,14 @@ import (
 )
 
 type ErrorResponse struct {
-	ID         *string `json:"id"`
+	ID         *uint   `json:"id"`
 	Error      string  `json:"error"`
 	Message    string  `json:"message"`
 	Stacktrace *string `json:"stacktrace,omitempty"`
 }
 
 type NewSessionResponse struct {
-	ID     *string          `json:"id"`
+	ID     *uint            `json:"id"`
 	Result NewSessionResult `json:"result"`
 }
 
@@ -30,7 +30,7 @@ type NewSessionCapabilities struct {
 }
 
 type GetSettingsResponse struct {
-	ID     string            `json:"id"`
+	ID     uint              `json:"id"`
 	Result RetrievedSettings `json:"result"`
 }
 
@@ -42,18 +42,18 @@ type RetrievedSetting struct {
 }
 
 type SetSettingsResponse struct {
-	ID     string      `json:"id"`
+	ID     uint        `json:"id"`
 	Result EmptyResult `json:"result"`
 }
 
 type PressKeysResponse struct {
-	ID     string      `json:"id"`
+	ID     uint        `json:"id"`
 	Result EmptyResult `json:"result"`
 }
 
 type EmptyResult interface{}
 
-func ErrorResponseJSON(error string, message string, id *string) []byte {
+func ErrorResponseJSON(error string, message string, id *uint) []byte {
 	c := ErrorResponse{
 		ID:      id,
 		Error:   error,
@@ -69,8 +69,9 @@ func ErrorResponseJSON(error string, message string, id *string) []byte {
 	return response
 }
 
-func NewSessionResponseJSON(info *client.Capabilities, sessionKey string) []byte {
+func NewSessionResponseJSON(info *client.Capabilities, sessionKey string, id *uint) []byte {
 	r := NewSessionResponse{
+		ID: id,
 		Result: NewSessionResult{
 			SessionID: sessionKey,
 			Capabilities: NewSessionCapabilities{

--- a/Server/server/server.go
+++ b/Server/server/server.go
@@ -123,7 +123,7 @@ func (s *Server) handleNewSessionCommand(message []byte) []byte {
 
 	go captureOutput()
 
-	return response.NewSessionResponseJSON(info, *s.sessionID)
+	return response.NewSessionResponseJSON(info, *s.sessionID, &c.ID)
 }
 
 func getRequestedSettings(command command.GetSettingsCommand) []string {
@@ -146,7 +146,7 @@ func mapSettingsToRetrievedSettings(settings *client.Settings) response.Retrieve
 	return s
 }
 
-func (s *Server) getSettings(ID *string, requested []string) []byte {
+func (s *Server) getSettings(ID *uint, requested []string) []byte {
 	res := response.GetSettingsResponse{ID: *ID}
 
 	settings, err := s.client.GetSettings(requested)
@@ -291,7 +291,7 @@ func (s *Server) handleAnyCommand(c command.AnyCommand, message []byte) []byte {
 	return handleUnknownCommand(&c.ID)
 }
 
-func handleUnknownCommand(ID *string) []byte {
+func handleUnknownCommand(ID *uint) []byte {
 	return response.ErrorResponseJSON("unknown command", "", ID)
 }
 


### PR DESCRIPTION
Fixes #40 and #42.

This is my first time trying to do anything with golang, and I didn't quite understand why some of these structs are `*string` vs `string`, but just kept everything the same swapping string for uint, and added the missing ID param to the new session result