### PR TITLE
remove nvda: prefix from settings commands

### DIFF
--- a/Server/command/command.go
+++ b/Server/command/command.go
@@ -2,9 +2,9 @@ package command
 
 const (
 	NewSessionCommandMethod           = "session.new"
-	GetSettingsCommandMethod          = "nvda:settings.getSettings"
-	GetSupportedSettingsCommandMethod = "nvda:settings.getSupportedSettings"
-	SetSettingsCommandMethod          = "nvda:settings.setSettings"
+	GetSettingsCommandMethod          = "settings.getSettings"
+	GetSupportedSettingsCommandMethod = "settings.getSupportedSettings"
+	SetSettingsCommandMethod          = "settings.setSettings"
 	UserIntentCommandMethod           = "interaction.userIntent"
 	PressKeysCommandName              = "pressKeys"
 )


### PR DESCRIPTION
These commands are part of the at-driver spec but don't have the `nvda:` prefix on them, I'd like to clean up this inconsistency.